### PR TITLE
Improve java dependencies in parquet generator

### DIFF
--- a/profiling/parquet-mr-custom/prelim/generate_parquetfiles.sh
+++ b/profiling/parquet-mr-custom/prelim/generate_parquetfiles.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Generate parquet files with
 # DataTypes int32, int64, str
@@ -10,8 +11,8 @@ outdir=/data/parquetfiles/new
 parquetwriter=~/workspaces/openCAPI/fast-p2a/software/cpp/test/parquetwriter_test
 parquetdebug=~/workspaces/openCAPI/fast-p2a/profiling/cpp-benchmarks/pagecounter/debug/pagecounter
 
-rm *.prq
-mkdir $outdir
+rm *.prq || true
+mkdir -p $outdir
 
 for datatype in int32 int64 str; do
 	if [ "$datatype" == "int32" ]; then

--- a/profiling/parquet-mr-custom/prelim/pom.xml
+++ b/profiling/parquet-mr-custom/prelim/pom.xml
@@ -28,20 +28,19 @@
       <dependency>
          <groupId>org.apache.parquet</groupId>
          <artifactId>parquet-avro</artifactId>
-         <version>1.12.0-SNAPSHOT</version>
+         <version>1.11.0</version>
       </dependency>
       <dependency>
          <groupId>org.apache.hadoop</groupId>
          <artifactId>hadoop-client</artifactId>
          <version>3.1.1</version>
       </dependency>
-<!-- https://mvnrepository.com/artifact/org.apache.parquet/parquet-column -->
-<dependency>
-    <groupId>org.apache.parquet</groupId>
-    <artifactId>parquet-column</artifactId>
-    <version>1.12.0-SNAPSHOT</version>
-</dependency>
-
+      <!-- https://mvnrepository.com/artifact/org.apache.parquet/parquet-column -->
+      <dependency>
+          <groupId>org.apache.parquet</groupId>
+          <artifactId>parquet-column</artifactId>
+          <version>1.11.0</version>
+      </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Changes use reflection API to access private field. This avoids building of custom parquet library